### PR TITLE
Bump Yargs to 16.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "lodash.pick": "^4.4.0",
     "lodash.template": "^4.5.0",
     "prop-types": "^15.7.2",
-    "yargs": "^15.0.2"
+    "yargs": "^16.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.10.4",


### PR DESCRIPTION
Yargs 16.1.1 resolves y18n vulernability that was fixed in y18n 5.0.5 (attached commit below)

Reference: https://snyk.io/vuln/SNYK-JS-Y18N-1021887

https://github.com/yargs/yargs/commit/ae001f34c968e8f4cda2a832d85b114753f4dee0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519